### PR TITLE
feat: part concatenation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,17 @@
 blank_issues_enabled: true
 contact_links:
   - name: 🎵 Carmen Documentation
-    url: https://github.com/francescofarina/carmen/blob/main/docs/language_manual.md
+    url: https://github.com/francescofarina/carmen-lang/blob/main/docs/language_manual.md
     about: Read the complete language manual and documentation
   - name: 📖 API Documentation
     url: https://docs.rs/carmen-lang
     about: Browse the API documentation on docs.rs
   - name: 💡 Examples & Tutorials
-    url: https://github.com/francescofarina/carmen/tree/main/examples
+    url: https://github.com/francescofarina/carmen-lang/tree/main/examples
     about: Check out Carmen code examples and tutorials
   - name: 🚀 Getting Started
-    url: https://github.com/francescofarina/carmen#carmen-language-quick-start
+    url: https://github.com/francescofarina/carmen-lang#carmen-language-quick-start
     about: Quick start guide for new users
   - name: 🤝 Contributing Guide
-    url: https://github.com/francescofarina/carmen/blob/main/CONTRIBUTING.md
+    url: https://github.com/francescofarina/carmen-lang/blob/main/CONTRIBUTING.md
     about: Learn how to contribute to Carmen development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ This project and everyone participating in it is governed by our [Code of Conduc
    ```
 3. **Add the upstream remote**:
    ```bash
-   git remote add upstream https://github.com/francescofarina/carmen.git
+   git remote add upstream https://github.com/francescofarina/carmen-lang.git
    ```
 4. **Build the project**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/carmen-lang.svg)](https://crates.io/crates/carmen-lang)
 [![Documentation](https://docs.rs/carmen-lang/badge.svg)](https://docs.rs/carmen-lang)
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/francescofarina/carmen#license)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/francescofarina/carmen-lang#license)
 
 ## Table of Contents
 
@@ -58,7 +58,7 @@ You will need to have the [Rust programming language](https://www.rust-lang.org/
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/francescofarina/carmen.git
+    git clone https://github.com/francescofarina/carmen-lang.git
     cd carmen
     ```
 2.  **Build the project:**
@@ -255,7 +255,7 @@ If you want to contribute to Carmen or work on the project for development purpo
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/francescofarina/carmen.git
+    git clone https://github.com/francescofarina/carmen-lang.git
     cd carmen
     ```
 2.  **Build in debug mode:**
@@ -275,7 +275,7 @@ We welcome contributions! Please see our [contributing guidelines](CONTRIBUTING.
 
 ## Community
 
-- **Issues & Bug Reports**: [GitHub Issues](https://github.com/francescofarina/carmen/issues)
+- **Issues & Bug Reports**: [GitHub Issues](https://github.com/francescofarina/carmen-lang/issues)
 - **Documentation**: [Language Manual](docs/language_manual.md)
 - **Crate Documentation**: [docs.rs/carmen-lang](https://docs.rs/carmen-lang)
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1838,6 +1838,10 @@ impl Interpreter {
             }
 
             // Pitch class set transposition
+            // Part concatenation
+            (Value::Part(a), BinaryOp::Add, Value::Part(b)) => Ok(Value::Part(a.merge(b))),
+
+            // Pitch class set transposition
             (Value::PitchClassSet(pcs), BinaryOp::Add, Value::Number(n)) => {
                 Ok(Value::PitchClassSet(pcs.transpose(*n as i32)))
             }

--- a/tests/integration/interpreter_test.rs
+++ b/tests/integration/interpreter_test.rs
@@ -31,3 +31,31 @@ score "Voices" {
         _ => panic!("Expected a score"),
     }
 }
+
+#[test]
+fn test_part_concatenation() {
+    let source = r#"
+let part1 = part "Violin" {
+    1/4 c4;
+    1/4 d4;
+};
+
+let part2 = part "Violin" {
+    1/4 e4;
+    1/4 f4;
+};
+
+part1 + part2;
+"#;
+
+    let result = run(source).unwrap();
+    match result {
+        Value::Part(part) => {
+            assert_eq!(part.events.len(), 4);
+            // Check offsets to ensure they are sequential
+            let offsets: Vec<_> = part.events.iter().map(|e| e.offset.to_f64()).collect();
+            assert_eq!(offsets, vec![0.0, 0.25, 0.5, 0.75]);
+        }
+        _ => panic!("Expected a Part value, got {:?}", result),
+    }
+}

--- a/tests/unit/core/mod.rs
+++ b/tests/unit/core/mod.rs
@@ -1105,6 +1105,27 @@ mod part_tests {
         // = 1.0 + 0.75 = 1.75
         assert_eq!(part.total_duration(), Fraction::new(7, 4));
     }
+
+    #[test]
+    fn test_part_merge() {
+        let mut part1 = Part::new(Some("Part 1".to_string()));
+        part1.add_event(MusicalEvent::note(
+            Pitch::from_note_name("c", 0, 4).unwrap(),
+            Duration::from_fraction(1, 4),
+        ));
+
+        let mut part2 = Part::new(Some("Part 2".to_string()));
+        part2.add_event(MusicalEvent::note(
+            Pitch::from_note_name("d", 0, 4).unwrap(),
+            Duration::from_fraction(1, 4),
+        ));
+
+        let merged_part = part1.merge(&part2);
+
+        assert_eq!(merged_part.events.len(), 2);
+        assert_eq!(merged_part.events[0].offset, Fraction::new(0, 1));
+        assert_eq!(merged_part.events[1].offset, Fraction::new(1, 4));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

This PR enables part concatenation with the + operator by adding a new method `merge` to the core `Part`.

### Related Issue

Closes #11 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔧 Build/CI changes
- [ ] 🧹 Chore (maintenance, dependencies, etc.)

## Carmen Code Examples

It is now possible to merge parts by doing

```carmen
let part1 = part "Violin" {
    1/4 c4;
    1/4 d4;
};

let part2 = part "Violin" {
    1/4 e4;
    1/4 f4;
};

part1 + part2;
```

## Checklist

- [x] PR title follows conventional commits format (`type(scope): description`)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published
- [x] All CI checks passed
